### PR TITLE
Add optional NeighborLoader training path

### DIFF
--- a/configs/gat.yaml
+++ b/configs/gat.yaml
@@ -15,6 +15,9 @@ weight_decay: 5.0e-5
 lr: 5.0e-4
 max_epochs: 250
 patience: 25
+mini_batch: false
+fanout: [10, 10]
+batch_size: 8192
 
 class_weight_pos: auto
 focal_loss: false

--- a/configs/gcn.yaml
+++ b/configs/gcn.yaml
@@ -14,6 +14,9 @@ weight_decay: 1.0e-4
 lr: 1.0e-3
 max_epochs: 200
 patience: 20
+mini_batch: false
+fanout: [10, 10]
+batch_size: 8192
 
 class_weight_pos: auto
 focal_loss: false

--- a/configs/sage.yaml
+++ b/configs/sage.yaml
@@ -14,6 +14,9 @@ weight_decay: 1.0e-4
 lr: 1.0e-3
 max_epochs: 200
 patience: 20
+mini_batch: false
+fanout: [10, 10]
+batch_size: 8192
 
 class_weight_pos: auto
 focal_loss: false


### PR DESCRIPTION
## Summary
- add mini-batch configuration options to the GCN, GraphSAGE, and GAT presets
- introduce NeighborLoader-based training and validation helpers controlled by the new config flags
- preserve the existing full-graph training path while unifying logging and calibration handling

## Testing
- python -m compileall src/train_gnn.py

------
https://chatgpt.com/codex/tasks/task_e_68e663a5c7148328b214a801aec38aba