### PR TITLE
Add temporal windowing options and export inference arrays

### DIFF
--- a/configs/gat.yaml
+++ b/configs/gat.yaml
@@ -27,3 +27,6 @@ precision_target: 0.90
 topk: 100
 
 calibrate_temperature: true
+symmetrize_edges: false
+use_time_scalar: false
+train_window_k: null   # e.g., 6 trains on last 6 steps of train period

--- a/configs/gcn.yaml
+++ b/configs/gcn.yaml
@@ -26,3 +26,6 @@ precision_target: 0.90
 topk: 100
 
 calibrate_temperature: true
+symmetrize_edges: false
+use_time_scalar: false
+train_window_k: null   # e.g., 6 trains on last 6 steps of train period

--- a/configs/sage.yaml
+++ b/configs/sage.yaml
@@ -26,3 +26,6 @@ precision_target: 0.90
 topk: 100
 
 calibrate_temperature: true
+symmetrize_edges: false
+use_time_scalar: false
+train_window_k: null   # e.g., 6 trains on last 6 steps of train period

--- a/src/data/dataset_elliptic.py
+++ b/src/data/dataset_elliptic.py
@@ -1,4 +1,6 @@
 
+from __future__ import annotations
+
 import os
 import pandas as pd
 import torch
@@ -89,7 +91,12 @@ def load_elliptic_as_graph(
     }
     return data, meta
 
-def make_temporal_masks(data: Data, t_train_end: int, t_val_end: int):
+def make_temporal_masks(
+    data: Data,
+    t_train_end: int,
+    t_val_end: int,
+    train_window_k: int | None = None,
+):
     # Build boolean masks over nodes for train/val/test using labeled nodes only.
     y = data.y
     t = data.timestep
@@ -98,6 +105,10 @@ def make_temporal_masks(data: Data, t_train_end: int, t_val_end: int):
     train_mask = (t <= t_train_end) & labeled
     val_mask = (t > t_train_end) & (t <= t_val_end) & labeled
     test_mask = (t > t_val_end) & labeled
+
+    if train_window_k is not None:
+        t_lo = max(1, t_train_end - train_window_k + 1)
+        train_mask = (t >= t_lo) & (t <= t_train_end) & labeled
 
     data.train_mask = train_mask
     data.val_mask = val_mask


### PR DESCRIPTION
## Summary
- extend GNN configs to include options for edge symmetrization, time scalars, and rolling train windows
- update dataset masking to support optional rolling windows and augment training with configurable edge/time features
- store per-node scores, labels, indices, and timesteps for validation and test splits across GNN and baseline training scripts

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e66a4afadc832888b4995f412ec5a0