### PR TITLE
Add EDA CLI for processed graph checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ python -m src.data.build_graph --config configs/split.yaml
 
 This writes `data/processed/graph.pt` and `data/processed/meta.json`.
 
+## EDA & Checks
+
+Generate quick sanity tables (degree histogram and labels by timestep) and
+optionally enforce that every edge stays within a single timestep:
+
+```bash
+python -m src.analysis.eda --processed_dir data/processed --assert_no_cross_time_edges
+```
+
+The script writes `degree_hist.csv` and `labels_by_time.csv` alongside the
+processed graph and prints a short summary.
+
 ## 3) Baselines
 
 Logistic regression:

--- a/src/analysis/eda.py
+++ b/src/analysis/eda.py
@@ -1,0 +1,154 @@
+"""Exploratory data analysis utilities for the processed Elliptic graph."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Tuple
+
+import torch
+
+
+def load_processed_graph(processed_dir: Path) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Dict]:
+    """Load the cached graph tensors from ``processed_dir``.
+
+    Returns the ``edge_index`` (``[2, E]``), node labels ``y``, timesteps, and the
+    loaded ``meta`` dictionary.
+    """
+
+    graph_path = processed_dir / "graph.pt"
+    meta_path = processed_dir / "meta.json"
+
+    if not graph_path.exists():
+        raise FileNotFoundError(f"Missing graph tensor at {graph_path}")
+    if not meta_path.exists():
+        raise FileNotFoundError(f"Missing meta information at {meta_path}")
+
+    data = torch.load(graph_path, map_location="cpu")
+    with open(meta_path, "r") as f:
+        meta = json.load(f)
+
+    if not hasattr(data, "edge_index"):
+        raise AttributeError("Loaded data object has no 'edge_index' attribute")
+    if not hasattr(data, "y"):
+        raise AttributeError("Loaded data object has no 'y' attribute")
+    if not hasattr(data, "timestep"):
+        raise AttributeError("Loaded data object has no 'timestep' attribute")
+
+    edge_index = data.edge_index.to(torch.long)
+    y = data.y.to(torch.long)
+    timestep = data.timestep.to(torch.long)
+
+    return edge_index, y, timestep, meta
+
+
+def write_degree_histogram(edge_index: torch.Tensor, num_nodes: int, out_path: Path) -> None:
+    """Compute degree counts (treating edges as undirected) and persist to CSV."""
+
+    if edge_index.numel() == 0:
+        degrees = torch.zeros(num_nodes, dtype=torch.long)
+    else:
+        degrees = torch.bincount(edge_index.view(-1), minlength=num_nodes)
+
+    unique_degrees, counts = torch.unique(degrees, return_counts=True, sorted=True)
+
+    with open(out_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["degree", "count"])
+        for degree_value, count in zip(unique_degrees.tolist(), counts.tolist()):
+            writer.writerow([int(degree_value), int(count)])
+
+
+def write_labels_by_time(
+    y: torch.Tensor, timestep: torch.Tensor, out_path: Path
+) -> Tuple[int, int, int]:
+    """Aggregate label counts per timestep and persist to CSV."""
+
+    unique_timesteps = torch.unique(timestep, sorted=True)
+
+    with open(out_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["timestep", "n_illicit", "n_licit", "n_unknown"])
+        for t in unique_timesteps.tolist():
+            mask = timestep == t
+            y_t = y[mask]
+            n_illicit = int((y_t == 1).sum())
+            n_licit = int((y_t == 0).sum())
+            n_unknown = int((y_t < 0).sum())
+            writer.writerow([int(t), n_illicit, n_licit, n_unknown])
+
+    total_illicit = int((y == 1).sum())
+    total_licit = int((y == 0).sum())
+    total_unknown = int((y < 0).sum())
+    return total_illicit, total_licit, total_unknown
+
+
+def assert_no_cross_time_edges(edge_index: torch.Tensor, timestep: torch.Tensor) -> None:
+    """Ensure every edge connects nodes from the same timestep."""
+
+    if edge_index.numel() == 0:
+        return
+
+    src_ts = timestep[edge_index[0]]
+    dst_ts = timestep[edge_index[1]]
+    mismatch = torch.nonzero(src_ts != dst_ts, as_tuple=False).view(-1)
+
+    if mismatch.numel() == 0:
+        return
+
+    print("Found cross-timestep edges (node_u, node_v, timestep_u, timestep_v):")
+    max_report = 20
+    for idx in mismatch.tolist()[:max_report]:
+        u = int(edge_index[0, idx])
+        v = int(edge_index[1, idx])
+        tu = int(src_ts[idx])
+        tv = int(dst_ts[idx])
+        print(f"  ({u}, {v}, {tu}, {tv})")
+    remaining = mismatch.numel() - max_report
+    if remaining > 0:
+        print(f"  ... and {remaining} more")
+    sys.exit(1)
+
+
+
+def main(processed_dir: Path, check_cross_time: bool) -> None:
+    edge_index, y, timestep, meta = load_processed_graph(processed_dir)
+    num_nodes = int(meta.get("num_nodes", y.size(0)))
+    num_edges = int(meta.get("num_edges", edge_index.size(1)))
+
+    if check_cross_time:
+        assert_no_cross_time_edges(edge_index, timestep)
+
+    degree_csv = processed_dir / "degree_hist.csv"
+    labels_csv = processed_dir / "labels_by_time.csv"
+
+    write_degree_histogram(edge_index, num_nodes, degree_csv)
+    totals = write_labels_by_time(y, timestep, labels_csv)
+
+    print(
+        "Graph summary: "
+        f"nodes={num_nodes}, edges={num_edges}; "
+        f"labels(illicit={totals[0]}, licit={totals[1]}, unknown={totals[2]}). "
+        f"Wrote {degree_csv.name} and {labels_csv.name}."
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="EDA and sanity checks for the processed Elliptic graph")
+    parser.add_argument(
+        "--processed_dir",
+        type=Path,
+        default=Path("data/processed"),
+        help="Directory containing graph.pt and meta.json",
+    )
+    parser.add_argument(
+        "--assert_no_cross_time_edges",
+        action="store_true",
+        help="Exit with error if any edge connects nodes from different timesteps",
+    )
+    args = parser.parse_args()
+
+    main(args.processed_dir, args.assert_no_cross_time_edges)


### PR DESCRIPTION
## Summary
- add a command-line EDA utility that writes degree histograms and label counts by timestep for the processed Elliptic graph
- include an optional assertion to guard against edges that cross timesteps
- document the new analysis command in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67366c19c832890889da3a449f881